### PR TITLE
Refactor Django Integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * switch development to uv/nox[uv] and replace custom requirements with uv.lock file
 * upgrade all requirements to latest version
 * add CONTRIBUTING.md docs
+* refactor Django integration (to preserve default translations)
 
 ## 1.7.0
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -21,6 +21,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 
+import django
+
 DATABASES = {
     "default": "postgres://myuser:mypasswd@localhost:5432/mydb",
     "analytics": "sqlite:///tmp/analytics.db",
@@ -39,6 +41,8 @@ PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",
 ]
 USE_TZ = True
+if django.VERSION < (4, 0):
+    USE_L10N = True
 
 INSTALLED_APPS = [
     "django.contrib.auth",

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -67,3 +67,19 @@ class MonkeyPatchDjangoTestCase(unittest.TestCase):
         self.assertEqual(settings.EMAIL_SSL_CERTFILE, "mycert")
         self.assertEqual(settings.EMAIL_SSL_KEYFILE, None)
         self.assertEqual(settings.EMAIL_TIMEOUT, 30)
+
+    def test_ensure_that_locale_keep_the_right_path(self) -> None:
+        import datetime as dt
+
+        from django.template import engines
+        from django.utils import translation
+
+        engine = engines.all()[0]
+        template = engine.from_string("{{ now }}")
+
+        with translation.override("en"):
+            output = template.render(context={"now": dt.date(2025, 3, 21)})
+            self.assertEqual(output, "March 21, 2025")
+        with translation.override("it"):
+            output = template.render(context={"now": dt.date(2025, 3, 21)})
+            self.assertEqual(output, "21 Marzo 2025")


### PR DESCRIPTION
The Django integration currently overrides the original Settings/LazySettings
instance with custom django-service-urls settings.
This causes the locale directory to be incorrectly resolved to
`django_service_urls/locale` instead of the default `django/conf/locale`
(see `sys.module[django.conf.settings.__module__].__file__` in
`django.utils.translation.trans_real.DjangoTranslation._init_translation_catalog`).
As a result, default translations, such as date formatting in template
rendering, are affected.
For example, for `LANGUAGE="it"` `datetime.date(2025, 3, 21)` renders as `"March 21, 2025"` (English) instead of the correct Italian translation `"21 Marzo 2025"`.

This refactor avoids introducing a custom settings override and instead
manipulates the original settings instance to ensure proper locale
resolution and preserve default translations.